### PR TITLE
Retrieve the doppler endpoint URL from CC.

### DIFF
--- a/src/wats/helpers_test.go
+++ b/src/wats/helpers_test.go
@@ -1,6 +1,7 @@
 package wats
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -70,7 +71,17 @@ func runCf(values ...string) func() error {
 func DopplerUrl(c Config) string {
 	doppler := os.Getenv("DOPPLER_URL")
 	if doppler == "" {
-		doppler = "wss://doppler." + c.AppsDomain + ":4443"
+		cfInfoBuffer, err := runCfWithOutput("curl", "/v2/info")
+		Expect(err).NotTo(HaveOccurred())
+
+		var cfInfo struct {
+			DopplerLoggingEndpoint string `json:"doppler_logging_endpoint"`
+		}
+
+		err = json.NewDecoder(cfInfoBuffer).Decode(&cfInfo)
+		Expect(err).NotTo(HaveOccurred())
+
+		doppler = cfInfo.DopplerLoggingEndpoint
 	}
 	return doppler
 }

--- a/src/wats/helpers_test.go
+++ b/src/wats/helpers_test.go
@@ -1,6 +1,7 @@
 package wats
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -78,7 +79,7 @@ func DopplerUrl(c Config) string {
 			DopplerLoggingEndpoint string `json:"doppler_logging_endpoint"`
 		}
 
-		err = json.NewDecoder(cfInfoBuffer).Decode(&cfInfo)
+		err = json.NewDecoder(bytes.NewReader(cfInfoBuffer.Contents())).Decode(&cfInfo)
 		Expect(err).NotTo(HaveOccurred())
 
 		doppler = cfInfo.DopplerLoggingEndpoint


### PR DESCRIPTION
We noticed that the doppler logging endpoint URL was incorrectly using the apps domain by default. This PR queries CC using the `/v2/info` API endpoint to determine the correct URL to use.

Signed-off-by: Zachary Gershman <zgershman@pivotal.io>