### PR TITLE
Change description of SOCKET_ADDRESS_FOR_SECURITY_GROUP_TEST flag

### DIFF
--- a/scripts/run_wats.sh
+++ b/scripts/run_wats.sh
@@ -13,7 +13,7 @@ else
 : ${ADMIN_USER:?"Must set admin username (e.g. admin)"}
 : ${ADMIN_PASSWORD:?"Must set admin password (e.g. admin)"}
 : ${APPS_DOMAIN:?"Must set app domain url (e.g. 10.244.0.34.xip.io)"}
-: ${SOCKET_ADDRESS_FOR_SECURITY_GROUP_TEST:?"Must set address [ip address of Diego ETCD cluster] (e.g. 10.244.16.2:4001)"}
+: ${SOCKET_ADDRESS_FOR_SECURITY_GROUP_TEST:?"Must set address [ip address of Diego ETCD cluster or BOSH Director] (e.g. 10.244.16.2:4001 or 10.0.0.6:25555)"}
 : ${NUM_WIN_CELLS:?"Must provide the number of windows cells in this deploy (e.g. 2)"}
 
 cat > $CONFIG_FILE <<HERE


### PR DESCRIPTION
In all our pipelines that are BOSH deployed we set this to be the BOSH director IP so we should document this as a possible value in the error message.