### PR TITLE
Remove outdated comment in security group tests

### DIFF
--- a/src/wats/security_group_test.go
+++ b/src/wats/security_group_test.go
@@ -55,9 +55,6 @@ var _ = Describe("Security Groups", func() {
 		ReturnCode int `json:"return_code"`
 	}
 
-	// this test assumes the default running security groups block access to the DEAs
-	// the test takes advantage of the fact that the DEA ip address and internal container ip address
-	//  are discoverable via the cc api and nora's myip endpoint
 	It("allows traffic and then blocks traffic", func() {
 		groups := unbindSecurityGroups()
 		defer bindSecurityGroups(groups)


### PR DESCRIPTION
Comment refers to DEA implementation details that aren't really relevant to the test any more.