### PR TITLE
add test for Diego task functionality

### DIFF
--- a/src/wats/tasks_test.go
+++ b/src/wats/tasks_test.go
@@ -1,0 +1,38 @@
+package wats
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+)
+
+var _ = Describe("Task Lifecycle", func() {
+	It("exercises the task lifecycle on windows", func() {
+		By("pushing it", func() {
+			Eventually(cf.Cf("push", appName, "-p", "../../assets/webapp", "-c", ".\\webapp.exe",
+				"--no-start", "-b", binaryBuildPackURL, "-s", "windows2012R2"), CF_PUSH_TIMEOUT).Should(Exit(0))
+		})
+
+		By("staging and running it on Diego", func() {
+			enableDiego(appName)
+			session := cf.Cf("start", appName)
+			Eventually(session, CF_PUSH_TIMEOUT).Should(Exit(0))
+		})
+
+		By("running a task", func() {
+			session := cf.Cf("run-task", appName, "cmd /c echo 'hello world'")
+			Eventually(session).Should(Exit(0))
+		})
+
+		By("checking the task has succeeded", func() {
+			Eventually(func() *Session {
+				taskSession := cf.Cf("tasks", appName)
+				Expect(taskSession.Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+				return taskSession
+			}).Should(Say("SUCCEEDED"))
+		})
+	})
+})


### PR DESCRIPTION
This commit adds a test for task functionality through the cf CLI. The
minimum cf CLI version necessary is 6.23.0. This test also relies on the
code changes made for story mentioned below within Diego.

Not quite sure how you all deal with version dependencies of diego-release, let me know if we should do something about that.

[#146897809]